### PR TITLE
Fixes compilation error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,13 +83,13 @@ class timezone (
       $_zone = split($timezone, '/')
       $zone = $_zone[1]
       exec { 'update_debconf area':
-        command => "echo tzdata tzdata/Areas select ${area} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -q -E \"^tzdata\\s+tzdata/Areas\\s+select\\s+${area}\"",
+        command => "/bin/echo tzdata tzdata/Areas select ${area} | /usr/bin/debconf-set-selections",
+        unless  => "/usr/bin/debconf-get-selections | /bin/grep -q -E \"^tzdata\\s+tzdata/Areas\\s+select\\s+${area}\"",
         path    => $::path,
       }
       exec { 'update_debconf zone':
-        command => "echo tzdata tzdata/Zones/${area} select ${timezone} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -E \"^tzdata\\s+tzdata/Zones/${area}\\s+select\\s+${zone}\"",
+        command => "/bin/echo tzdata tzdata/Zones/${area} select ${timezone} | /usr/bin/debconf-set-selections",
+        unless  => "/usr/bin/debconf-get-selections | /bin/grep -E \"^tzdata\\s+tzdata/Zones/${area}\\s+select\\s+${zone}\"",
         path    => $::path,
       }
     }


### PR DESCRIPTION
```
Failure/Error: it { should compile }
       error during compilation: Parameter unless failed on Exec[update_debconf area]: 'debconf-get-selections |grep -q -E "^tzdata\s+tzdata/Areas\s+select\s+America"' is not qualified and no path was specified. Please qualify the command or specify a path. at /Users/carlos/Code/puppet/modules/test/spec/fixtures/modules/timezone/manifests/init.pp:85
```